### PR TITLE
Allow local directories to be created in Docker container

### DIFF
--- a/data/.dockerignore
+++ b/data/.dockerignore
@@ -1,0 +1,6 @@
+.venv
+input
+output
+Dockerfile
+README.md
+.gitignore

--- a/data/Dockerfile
+++ b/data/Dockerfile
@@ -6,6 +6,9 @@ RUN groupadd --system --gid 999 nonroot \
 
 WORKDIR /app
 
+RUN chown nonroot:nonroot /app
+
+ENV TQDM_MININTERVAL=5
 ENV UV_COMPILE_BYTECODE=1
 ENV UV_LINK_MODE=copy
 ENV UV_TOOL_BIN_DIR=/usr/local/bin

--- a/data/README.md
+++ b/data/README.md
@@ -60,7 +60,7 @@ The Docker image expects two bind mounts:
 #### Example: Generate data.json from existing Minerva files
 
 ```bash
-docker run --rm \
+docker run --rm --tty \
   -v /path/to/minerva/files:/data/minerva:ro \
   -v /path/to/output:/data/output \
   geneontology/go-cam-browser-data-generator \
@@ -69,10 +69,16 @@ docker run --rm \
   --output-directory /data/output
 ```
 
+> [!NOTE]  
+> Be sure to specify a published tag (e.g. `geneontology/go-cam-browser-data-generator:main`) unless you built the image locally with the default `latest` tag.
+
+> [!NOTE]  
+> The `--tty` flag is only necessary if you want to see live-updating progress bars. This may be omitted in automated processes.
+
 #### Example: Download, index, and generate data.json
 
 ```bash
-docker run --rm \
+docker run --rm --tty \
   -v /path/to/output:/data/output \
   geneontology/go-cam-browser-data-generator \
   --download \

--- a/data/main.py
+++ b/data/main.py
@@ -128,15 +128,15 @@ def main(
     """Generate search documents from GO-CAM models."""
     if download:
         shutil.rmtree(minerva_directory, ignore_errors=True)
-        minerva_directory.mkdir(exist_ok=True)
+        minerva_directory.mkdir(exist_ok=True, parents=True)
         download_latest_release_gocams(minerva_directory)
 
     if download or index:
         shutil.rmtree(indexed_directory, ignore_errors=True)
-        indexed_directory.mkdir(exist_ok=True)
+        indexed_directory.mkdir(exist_ok=True, parents=True)
         generate_indexed_models(minerva_directory, indexed_directory)
 
-    output_directory.mkdir(exist_ok=True)
+    output_directory.mkdir(exist_ok=True, parents=True)
     generate_search_documents(indexed_directory, output_directory / "data.json")
 
 


### PR DESCRIPTION
Fixes #23 

These changes address issues around creating local data directories when running in the Docker container. In particular:

* Use `parents=True` with `mkdir` so that intermediate directories get created when necessary
* Set the owner of the `/app` directory to the non-privileged user in the container