### PR TITLE
Add Google Analytics 4

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,18 +1,6 @@
 <!doctype html>
 <html lang="en">
   <head>
-    <script
-      async
-      src="https://www.googletagmanager.com/gtag/js?id=G-MR617LRG6M"
-    ></script>
-    <script>
-      window.dataLayer = window.dataLayer || [];
-      function gtag() {
-        dataLayer.push(arguments);
-      }
-      gtag("js", new Date());
-      gtag("config", "G-MR617LRG6M");
-    </script>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>GO-CAM Browser</title>

--- a/src/components/Analytics.tsx
+++ b/src/components/Analytics.tsx
@@ -1,0 +1,40 @@
+import { config } from "../config.tsx";
+
+/**
+ * Analytics component that sets up Google Analytics using the provided googleTagID.
+ *
+ * It only initializes analytics in production mode and if the googleTagID is set.
+ *
+ * Note: This component relies on support for document metadata tags introduced in React 19.
+ * See also: https://react.dev/reference/react-dom/components/script
+ */
+const Analytics = () => {
+  if (import.meta.env.DEV) {
+    console.warn("Skipping analytics setup in development mode");
+    return null;
+  }
+  if (!config.googleTagID) {
+    console.warn("Skipping analytics setup because googleTagID is not set");
+    return null;
+  }
+  return (
+    <>
+      <script
+        async={true}
+        src={`https://www.googletagmanager.com/gtag/js?id=${config.googleTagID}`}
+      />
+      <script>
+        {`
+            window.dataLayer = window.dataLayer || [];
+            function gtag() {
+              dataLayer.push(arguments);
+            }
+            gtag("js", new Date());
+            gtag("config", "${config.googleTagID}");
+        `}
+      </script>
+    </>
+  );
+};
+
+export default Analytics;

--- a/src/config.tsx
+++ b/src/config.tsx
@@ -7,6 +7,7 @@ const goCamField = createFieldConfig<IndexedGoCam>();
 export const config = createConfig<IndexedGoCam>({
   title: "GO-CAM Browser",
   description: "Search and filter models by multiple criteria",
+  googleTagID: "G-MR617LRG6M",
   dataUrl: import.meta.env.BASE_URL + "data.json",
   headerLinks: [
     {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,6 +2,7 @@ import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import { createTheme, MantineProvider } from "@mantine/core";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import Analytics from "./components/Analytics.tsx";
 import App from "./App.tsx";
 
 import "@mantine/core/styles.css";
@@ -14,6 +15,7 @@ createRoot(document.getElementById("root")!).render(
   <StrictMode>
     <MantineProvider theme={theme}>
       <QueryClientProvider client={queryClient}>
+        <Analytics />
         <App />
       </QueryClientProvider>
     </MantineProvider>

--- a/src/types.ts
+++ b/src/types.ts
@@ -38,6 +38,7 @@ export interface AppConfig<
 > {
   title: string;
   description: string;
+  googleTagID?: string;
   dataUrl: string;
   headerLinks?: {
     label: string;


### PR DESCRIPTION
Add hard-coded GA4 for #24.

---

_Edit:_

In the latest commit I moved the Google tag ID into the site configuration object. The `<script>` tags are conditionally rendered in the React component tree. They are _not_ rendered if the Google tag ID is not set _or_ when running in development mode.