### PR TITLE
Manually inject script tags for GA

### DIFF
--- a/src/components/Analytics.tsx
+++ b/src/components/Analytics.tsx
@@ -7,7 +7,7 @@ import { config } from "../config.tsx";
  * It only initializes analytics in production mode and if the googleTagID is set.
  *
  * Note: This component manually injects <script> tags into the document head to load Google
- *       Analytics. It does not rely on Reach 19's built-in <script> tag handling because that
+ *       Analytics. It does not rely on React 19's built-in <script> tag handling because that
  *       does not execute inline script content.
  *       See:
  *         - https://react.dev/reference/react-dom/components/script


### PR DESCRIPTION
Related to #24 

The previous approach of using `react-dom`'s `<script>` tag handling wasn't working due to a React bug. These changes replace that approach with injecting the necessary script tags manually in a `useEffect` hook.