### PR TITLE
Make gene label field searchable

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -28,10 +28,6 @@ import ResultsDisplay from "./components/ResultsDisplay.tsx";
 
 import classes from "./App.module.css";
 
-const SEARCH_FIELDS = config.fields
-  .filter((f) => f.searchable)
-  .map((f) => f.field);
-
 function ScrollAreaWrapper({ children }: { children: React.ReactNode }) {
   return <ScrollArea offsetScrollbars>{children}</ScrollArea>;
 }
@@ -49,8 +45,6 @@ function App() {
     search,
   } = useSearch({
     data: data,
-    idField: "id",
-    searchFields: SEARCH_FIELDS,
   });
 
   const {

--- a/src/components/SearchInput.tsx
+++ b/src/components/SearchInput.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from "react";
 import { Input, TextInput } from "@mantine/core";
 import { useDebouncedCallback } from "@mantine/hooks";
+import { config } from "../config.tsx";
 
 interface SearchInputProps {
   disabled?: boolean;
@@ -24,10 +25,10 @@ const SearchInput: React.FC<SearchInputProps> = ({ disabled, onSearch }) => {
 
   return (
     <TextInput
-      aria-label="Search GO-CAMs"
+      aria-label={config.searchPlaceholder}
       size="lg"
       flex="1"
-      placeholder="Search GO-CAMs"
+      placeholder={config.searchPlaceholder}
       value={search}
       disabled={disabled}
       onChange={handleChange}

--- a/src/config.tsx
+++ b/src/config.tsx
@@ -7,6 +7,7 @@ const goCamField = createFieldConfig<IndexedGoCam>();
 export const config = createConfig<IndexedGoCam>({
   title: "GO-CAM Browser",
   description: "Search and filter models by multiple criteria",
+  searchPlaceholder: "Search GO-CAMs by title or gene",
   googleTagID: "G-MR617LRG6M",
   dataUrl: import.meta.env.BASE_URL + "data.json",
   headerLinks: [
@@ -29,6 +30,7 @@ export const config = createConfig<IndexedGoCam>({
   fields: [
     goCamField({
       field: "id",
+      isId: true,
       label: "Model ID",
       searchable: true,
       defaultVisible: false,
@@ -37,6 +39,7 @@ export const config = createConfig<IndexedGoCam>({
       field: "title",
       label: "Title",
       searchable: true,
+      searchFuzzy: true,
       render: (title, gocam) => (
         <BioregistryLink id={gocam.id}>{title}</BioregistryLink>
       ),
@@ -82,6 +85,7 @@ export const config = createConfig<IndexedGoCam>({
     goCamField({
       field: "model_activity_enabled_by_genes_label",
       label: "Genes",
+      searchable: true,
       facet: "array",
       render: (value, gocam) => (
         <TermLinkList

--- a/src/types.ts
+++ b/src/types.ts
@@ -21,8 +21,10 @@ export type IndexedGoCam = {
 
 export interface FieldConfig<TData, TField extends keyof TData = keyof TData> {
   field: TField;
+  isId: boolean;
   label: string;
   searchable: boolean;
+  searchFuzzy: boolean;
   facet?: "text" | "array" | "numeric";
   facetHelp?: ReactNode;
   defaultVisible: boolean;
@@ -38,6 +40,7 @@ export interface AppConfig<
 > {
   title: string;
   description: string;
+  searchPlaceholder: string;
   googleTagID?: string;
   dataUrl: string;
   headerLinks?: {
@@ -57,8 +60,10 @@ export function createFieldConfig<TData>() {
   ): FieldConfig<TData, TField> {
     return {
       field: config.field,
+      isId: config.isId ?? false,
       label: config.label ?? String(config.field),
       searchable: config.searchable ?? false,
+      searchFuzzy: config.searchFuzzy ?? false,
       facet: config.facet,
       facetHelp: config.facetHelp,
       defaultVisible: config.defaultVisible ?? true,
@@ -79,6 +84,16 @@ export function createConfig<
     keyof TData
   >[] = readonly FieldConfig<TData, keyof TData>[],
 >(config: AppConfig<TData, TFields>): AppConfig<TData, TFields> {
+  if (config.fields.length === 0) {
+    throw new Error("At least one field must be defined in config");
+  }
+  const idFields = config.fields.filter((f) => f.isId);
+  if (idFields.length === 0) {
+    throw new Error("No ID field defined in config");
+  }
+  if (idFields.length > 1) {
+    throw new Error("Multiple ID fields defined in config");
+  }
   return config;
 }
 


### PR DESCRIPTION
Fixes #37 

* Adds `model_activity_enabled_by_genes_label` to the searchable fields.
* Adds a `searchFuzzy` config field to control which encoder is used on each searchable field. We only want basic stemming done on ID and gene label fields, but we can be a little more fuzzy on title.
* Moves the search placeholder text to configuration, and it now mentions title and gene specifically. It does not mention ID even though that's still searchable because ID is hidden by default.